### PR TITLE
Remove object check in parse value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,10 +42,7 @@ function createStorage() {
 
 function parseValue(value) {
   try {
-    const v = JSON.parse(value);
-    if (v && typeof v === 'object' && v !== null) {
-      return v;
-    }
+    return JSON.parse(value);
   } catch (err) {
     return value;
   }


### PR DESCRIPTION
If I set only string don't throw the check end return stringify string

example:

```
dispatch(localStorage.setItem('foo', 'bar')).then(
  dispatch(localStorage.getItem('foo')).then(item => {
    console.log(item) // "bar"
  })
)
```
